### PR TITLE
feat: expose frontend on port 3010

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 docker compose up -d --build
 ```
 
-- Frontend: http://localhost:3000
+- Frontend: http://localhost:3010
 - Backend (Swagger): http://localhost:8000/docs
 
 ## Что реализовано

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   frontend:
     build: ./frontend
     ports:
-      - "3000:3000"
+      - "3010:3010"
     environment:
       - VITE_API_BASE=http://localhost:8000
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,5 +9,5 @@ COPY public /app/public
 RUN npm install
 COPY src /app/src
 
-EXPOSE 3000
+EXPOSE 3010
 CMD ["npm", "run", "dev"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "tsc && vite build",
-    "preview": "vite preview --port 3000 --host 0.0.0.0"
+    "preview": "vite preview --port 3010 --host 0.0.0.0"
   },
   "dependencies": {
     "axios": "^1.7.2",

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,5 +3,5 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  server: { port: 3000, host: true },
+  server: { port: 3010, host: true },
 })


### PR DESCRIPTION
## Summary
- switch frontend to port 3010 in docker-compose and Vite config
- update Dockerfile, preview script, and README to use port 3010
- add Vite env type definition for TypeScript

## Testing
- `python -m py_compile backend/src/main.py`
- `npm run build` *(fails: "@vitejs/plugin-react" resolved to an ESM file. ESM file cannot be loaded by `require`)*

------
https://chatgpt.com/codex/tasks/task_e_68b16bf2b1a0832e9a5b96080ad66d00