### PR TITLE
Switch backend to port 8023

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ docker compose up -d --build
 ```
 
 - Frontend: http://localhost:3000
-- Backend (Swagger): http://localhost:8000/docs
+- Backend (Swagger): http://localhost:8023/docs
 
 ## Что реализовано
 - Загрузка Excel: `/api/upload/hyperv`, `/api/upload/exchange`, `/api/upload/s3`, `/api/upload/bin-mapping`
@@ -71,13 +71,13 @@ docker compose up -d --build
 ## Пример запросов
 ```bash
 # Загрузка Hyper‑V
-curl -F "file=@hyper-v.xlsx" http://localhost:8000/api/upload/hyperv
+curl -F "file=@hyper-v.xlsx" http://localhost:8023/api/upload/hyperv
 
 # Отчет Hyper‑V
-curl http://localhost:8000/api/reports/hyperv
+curl http://localhost:8023/api/reports/hyperv
 
 # Экспорт
-curl -OJ http://localhost:8000/api/export/hyperv
+curl -OJ http://localhost:8023/api/export/hyperv
 ```
 
 ## Примечание

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install --no-cache-dir -r /app/requirements.txt
 COPY src /app/src
 COPY uploads /app/uploads
 
-EXPOSE 8000
-CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]
+EXPOSE 8023
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8023"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   backend:
     build: ./backend
     ports:
-      - "8000:8000"
+      - "8023:8023"
     volumes:
       - ./backend/uploads:/app/uploads
     environment:
@@ -16,7 +16,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - VITE_API_BASE=http://localhost:8000
+      - VITE_API_BASE=http://localhost:8023
     depends_on:
       - backend
     restart: unless-stopped

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,7 @@
+/// <reference types="vite/client" />
 import axios from "axios";
 
-const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8000";
+const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8023";
 
 export const api = axios.create({
   baseURL: API_BASE,


### PR DESCRIPTION
## Summary
- update backend and frontend configurations to use port 8023
- document new backend URL and API examples

## Testing
- `python -m pytest`
- `npm --prefix frontend run build` *(fails: Cannot find module '@vitejs/plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_68b16eeb38a0832e9986957c44510c7c