### PR TITLE
Expose frontend on 3010 and map backend to 8023

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   frontend:
     build: ./frontend
     ports:
-      - "3010:3010"
+      - "3010:3000"
     environment:
       - VITE_API_BASE=http://localhost:8023
     depends_on:

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  server: { port: 3010, host: true },
+  server: { port: 3000, host: true },
+  preview: { host: true }
 })


### PR DESCRIPTION
## Summary
- Map frontend container port 3000 to host 3010 and point API base to backend
- Run Vite dev server on internal port 3000 with host binding

## Testing
- `pytest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b177ed7ec4832e83a4b98a4dfeb0e3